### PR TITLE
Add callcatcher-CC/CXX/AR commands

### DIFF
--- a/README
+++ b/README
@@ -27,12 +27,17 @@ e.g.
  callcatcher g++ -o mytest test.o
  callanalyse mytest
 
-typically for autoconf and cmake etc, setting CC/CXX/AR is sufficient
+typically for autoconf, setting CC/CXX/AR is sufficient
 
  export CC="callcatcher gcc"
  export CXX="callcatcher g++"
  export AR="callarchive ar"
  ./configure && make
+
+To use callcatcher from within a cmake-based project, use the following setup:
+
+ mkdir build && cd build
+ cmake -DCMAKE_C_COMPILER="callcatcher-CC" -DCMAKE_CXX_COMPILER="callcatcher-CXX" -DCMAKE_AR="callcatcher-AR" ..
 
 The tool attempts to know what the dependant components are for a given output
 file, and so in the example above ./analyse.py mytest will only report on

--- a/scripts/callcatcher-AR
+++ b/scripts/callcatcher-AR
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+CALLCATCHER_AR="${CALLCATCHER_AR:-ar}"
+callcatcher "$CALLCATCHER_AR" "$@"

--- a/scripts/callcatcher-CC
+++ b/scripts/callcatcher-CC
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+CALLCATCHER_CC="${CALLCATCHER_CC:-gcc}"
+callcatcher "$CALLCATCHER_CC" "$@"

--- a/scripts/callcatcher-CXX
+++ b/scripts/callcatcher-CXX
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+CALLCATCHER_CXX="${CALLCATCHER_CXX:-g++}"
+callcatcher "$CALLCATCHER_CXX" "$@"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='callcatcher',
       author='Caolán McNamara',
       author_email='caolanm@redhat.com',
       url='http://www.skynet.ie/~caolan/Packages/callcatcher.html',
-      scripts=['scripts/callcatcher', 'scripts/callanalyse', 'scripts/callarchive'],
+      scripts=['scripts/callcatcher', 'scripts/callanalyse', 'scripts/callarchive', 'scripts/callcatcher-CC', 'scripts/callcatcher-CXX', 'scripts/callcatcher-AR'],
       packages=['callcatcher']
      )


### PR DESCRIPTION
This fixes #4.
To be able to use callcatcher from within a cmake-based project, one the environment variables `CC`, `CXX` and `AR` must point to executables. Strings such as `callcatcher gcc` are not supported. We thus introduce "wrapper compilers": `callcatcher-CC`, `callcatcher-CXX` and `callcatcher-AR`, which default to calling `callcatcher gcc/g++/ar`, but can be overriden using the environment variables `CALLCATCHER_CC/CALLCATCHER_CXX/CALLCATCHER_AR` (Directly using `CC/CXX/AR` would not work as this would cause an infinite recursion)
  
  