### PR TITLE
Fix unbound variable access

### DIFF
--- a/scripts/callanalyse
+++ b/scripts/callanalyse
@@ -19,10 +19,7 @@ if __name__ == '__main__':
 	except getopt.GetoptError:
 		showusage = True
 
-	if not len(inputs):
-		showusage = True
-
-	if showusage:
+	if showusage or not inputs:
 		# print help information and exit:
 	        usage()
 	        sys.exit(2)


### PR DESCRIPTION
Avoid an exception if the arguments are ill-formed and `input` is not initialized.