### PR TITLE
Rename short option for LibreOffice to L

### DIFF
--- a/scripts/callanalyse
+++ b/scripts/callanalyse
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 		    strict = True
 		if o in ("-d", "--detailed"):
 		    detailed = True
-		if o in ("-O", "--LibreOffice"):
+		if o in ("-L", "--LibreOffice"):
 		    LibO = True
 		if o in ("-m", "--mapfile"):
 		    mapfile = a


### PR DESCRIPTION
It was changed in the help but not in the code causing an error when using L and help not helping